### PR TITLE
pick images and proj page display to window

### DIFF
--- a/application/CMakeLists.txt
+++ b/application/CMakeLists.txt
@@ -67,6 +67,7 @@ set(PROJECT_SOURCES
     src/pages/calibration/calibrationPage.h
     src/pages/calibration/calibrationPage.cpp
     src/pages/calibration/calibrationPage.ui
+    src/utils/image_utils.h
 )
 
 add_executable(gpms_ui ${PROJECT_SOURCES})

--- a/application/src/mainwindow.cpp
+++ b/application/src/mainwindow.cpp
@@ -73,9 +73,9 @@ void MainWindow::setupPages()
     sensitivityPage = new SensitivityPage(imageProjectionWindow, this);
     // what will these show
     textVisionPage = new TextVisionPage(this);
-    pickImagesPage = new PickImagesPage(this);
+    pickImagesPage = new PickImagesPage(imageProjectionWindow, this);
     // will show projected image
-    projectPage = new ProjectPage(this);
+    projectPage = new ProjectPage(imageProjectionWindow, this);
 
     stackedWidget->addWidget(createPage);
 
@@ -124,6 +124,10 @@ void MainWindow::setupConnections()
     connect(pickImagesPage, &PickImagesPage::navigateToTextVisionPage, this, &MainWindow::navigateToTextVisionPage);
     connect(pickImagesPage, &PickImagesPage::navigateToProjectPage, this, &MainWindow::navigateToProjectPage);
     connect(pickImagesPage, &PickImagesPage::navigateToSensitivityPage, this, &MainWindow::navigateToSensitivityPage);
+
+    // from project page
+    connect(projectPage, &ProjectPage::navigateToCreatePage, this, &MainWindow::navigateToCreatePage);
+    connect(projectPage, &ProjectPage::navigateToPickImagesPage, this, &MainWindow::navigateToPickImagesPage);
 }
 
 void MainWindow::navigateToCreatePage()
@@ -164,8 +168,53 @@ void MainWindow::navigateToPickImagesPage()
     stackedWidget->setCurrentWidget(pickImagesPage);
 }
 
-void MainWindow::navigateToProjectPage()
+void MainWindow::navigateToProjectPage(const cv::Mat& selectedImage)
 {
+
+    // if (selectedImage.isNull()) {
+    //     qDebug() << "Error: selectedImage is null";
+    //     return;
+    // }
+
+    // qDebug() << "Original QPixmap size:" << selectedImage.size();
+
+    // QImage qImage = selectedImage.toImage();
+    // qImage = qImage.convertToFormat(QImage::Format_RGB888);
+    // qDebug() << "QImage format:" << qImage.format();
+
+    // cv::Mat cvImage;
+    // switch(qImage.format()) {
+    // case QImage::Format_RGBA8888:
+    //     qDebug() << "Converting from Format_RGBA8888";
+    //     cvImage = cv::Mat(qImage.height(), qImage.width(), CV_8UC4, (uchar*)qImage.bits(), qImage.bytesPerLine());
+    //     cv::cvtColor(cvImage, cvImage, cv::COLOR_RGBA2BGR);
+    //     break;
+    // case QImage::Format_RGB888:
+    //     qDebug() << "Converting from Format_RGB888";
+    //     cvImage = cv::Mat(qImage.height(), qImage.width(), CV_8UC3, (uchar*)qImage.bits(), qImage.bytesPerLine());
+    //     cv::cvtColor(cvImage, cvImage, cv::COLOR_RGB2BGR);
+    //     break;
+    // default:
+    //     qDebug() << "Unsupported QImage format:" << qImage.format();
+    //     return;
+    // }
+
+    // qDebug() << "cvImage size:" << cvImage.size().width << "x" << cvImage.size().height;
+    // qDebug() << "cvImage channels:" << cvImage.channels();
+    // qDebug() << "cvImage type:" << cvImage.type();
+
+    // // Check if the image has any non-zero pixels
+    // cv::Scalar sum = cv::sum(cvImage);
+    // qDebug() << "Image sum:" << sum[0] + sum[1] + sum[2] + sum[3];
+
+    // // Save the debug image
+    // QString debugImagePath = QDir::currentPath() + "/debug_image.png";
+    // cv::imwrite(debugImagePath.toStdString(), cvImage);
+    // qDebug() << "Saved debug image to:" << debugImagePath;
+
+    imageProjectionWindow->setStillFrame(selectedImage);
+    imageProjectionWindow->setProjectionState(ImageProjectionWindow::projectionState::IMAGE);
+    projectPage->setSelectedImage(selectedImage);
     stackedWidget->setCurrentWidget(projectPage);
 }
 

--- a/application/src/mainwindow.h
+++ b/application/src/mainwindow.h
@@ -67,7 +67,7 @@ private slots:
     void navigateToSensitivityPage();
     void navigateToTextVisionPage();
     void navigateToPickImagesPage();
-    void navigateToProjectPage();
+    void navigateToProjectPage(const cv::Mat& image);
 
 };
 #endif // MAINWINDOW_H

--- a/application/src/pages/imageprojectionwindow.cpp
+++ b/application/src/pages/imageprojectionwindow.cpp
@@ -53,6 +53,18 @@ void ImageProjectionWindow::setStillFrame(const cv::Mat &mat)
     setProjectionState(m_state);
 }
 
+void ImageProjectionWindow::setFinalFrame(const cv::Mat &mat)
+{
+    qDebug("In setFinalFRame");
+    if (mat.empty()) {
+        qDebug() << "Empty Mat provided to setStillFrame.";
+        return;
+    }
+
+    m_finalFrame = mat.clone(); // Clone to ensure data integrity
+    setProjectionState(m_state);
+}
+
 void ImageProjectionWindow::setSensitivity(int lo, int hi)
 {
     m_loSensitivity = lo;
@@ -103,6 +115,7 @@ void ImageProjectionWindow::setProjectionState(projectionState state)
         activateRainbowEdge();
         break;
     case projectionState::IMAGE:
+        qDebug("calling activate image");
         activateImage();
         break;
     default:
@@ -123,6 +136,9 @@ QImage ImageProjectionWindow::getCurrentImage() const
         if (!pix->isNull()) {
             return pix->toImage();
         }
+    }
+    else{
+        qDebug("In getCurrentImage, m_imageLabel is null");
     }
     return QImage(); // Return an empty QImage if there's no pixmap
 }
@@ -200,16 +216,16 @@ void ImageProjectionWindow::activateRainbowEdge()
 // Activate IMAGE state (apply perspective transform)
 void ImageProjectionWindow::activateImage()
 {
-    if (m_stillFrame.empty()) {
+    if (m_finalFrame.empty()) {
         qDebug() << "No still frame set for image projection.";
         return;
     }
 
     // Apply perspective transform using the helper function
-    cv::Mat warpedMat = applyPerspectiveTransform(m_stillFrame);
+    cv::Mat warpedMat = applyPerspectiveTransform(m_finalFrame);
 
     if (!warpedMat.empty()) {
-        updateImage(warpedMat);
+        updateImage(m_finalFrame); // setting m_imageLabel to contain this image
     }
     else {
         qDebug() << "Failed to apply perspective transform in activateImage().";
@@ -262,6 +278,13 @@ void ImageProjectionWindow::updateImage(const cv::Mat &mat)
             );
 
         m_imageLabel->setPixmap(pixmap);
+
+        qDebug() << "QImage created successfully. Size:" << image.size();
+        qDebug() << "Scaled pixmap size:" << pixmap.size();
+        qDebug() << "Label size:" << m_imageLabel->size();
+        qDebug() << "Label geometry:" << m_imageLabel->geometry();
+        qDebug() << "Label is visible:" << m_imageLabel->isVisible();
+
     }
     else
     {

--- a/application/src/pages/imageprojectionwindow.h
+++ b/application/src/pages/imageprojectionwindow.h
@@ -24,6 +24,7 @@ public:
 
     // Setters
     void setStillFrame(const cv::Mat &image);
+    void setFinalFrame(const cv::Mat &mat);
     void setSensitivity(int lo, int hi);
     void setTransformCorners(const std::array<cv::Point2f, 4>& transformCorners);
     void setProjectionState(projectionState state);
@@ -36,6 +37,7 @@ private:
     static constexpr int WIDTH = 1280, HEIGHT = 720;
 
     cv::Mat m_stillFrame;
+    cv::Mat m_finalFrame;
     int m_loSensitivity, m_hiSensitivity;
     std::array<cv::Point2f, 4> m_transformCorners;
     projectionState m_state;

--- a/application/src/pages/pickimagespage.h
+++ b/application/src/pages/pickimagespage.h
@@ -1,5 +1,6 @@
 #ifndef PICKIMAGESPAGE_H
 #define PICKIMAGESPAGE_H
+#include "imageprojectionwindow.h"
 
 #include <QWidget>
 #include <QFrame>
@@ -8,10 +9,9 @@
 #include <QPushButton>
 #include <QNetworkAccessManager>
 #include <QNetworkReply>
+#include <opencv2/imgproc.hpp>
+#include <opencv2/imgcodecs.hpp>
 
-namespace Ui {
-class PickImagesPage;
-}
 
 class ClickableFrame : public QFrame
 {
@@ -21,17 +21,25 @@ public:
     explicit ClickableFrame(QWidget *parent = nullptr);
     void setSelected(bool selected);
     bool isSelected() const;
-
-protected:
-    void mousePressEvent(QMouseEvent *event) override;
+    void setImage(const cv::Mat& mat);
+    cv::Mat getImage() const;
 
 signals:
     void clicked();
 
+protected:
+    void mousePressEvent(QMouseEvent *event) override;
+
 private:
     bool m_selected;
+    cv::Mat m_image;
+    QLabel* m_imageLabel;
     void updateStyle();
 };
+
+namespace Ui {
+class PickImagesPage;
+}
 
 
 class PickImagesPage : public QWidget
@@ -39,21 +47,24 @@ class PickImagesPage : public QWidget
     Q_OBJECT
 
 public:
-    explicit PickImagesPage(QWidget *parent = nullptr);
+    explicit PickImagesPage(ImageProjectionWindow *projectionWindow, QWidget *parent = nullptr);
     ~PickImagesPage();
+    cv::Mat getSelectedImage() const;
 
 signals:
     void navigateToTextVisionPage();
     void navigateToSensitivityPage();
-    void navigateToProjectPage(const QList<int>& selectedIndices);
+    void navigateToProjectPage(const cv::Mat& image);
 
 private slots:
     void onAcceptButtonClicked();
     void onRejectButtonClicked();
     void onRetakePhotoButtonClicked();
+    void handleImageResponse(QNetworkReply* reply);
 
 private:
     Ui::PickImagesPage *ui;
+    ImageProjectionWindow *m_projectionWindow;
     QList<ClickableFrame*> m_imageFrames;
     ClickableFrame* m_selectedFrame;
     QNetworkAccessManager *m_networkManager;
@@ -64,10 +75,10 @@ private:
     QHBoxLayout* createButtonLayout();
     QPushButton* styleButton(QPushButton* button, const QString& text, const QString& bgColor);
     void updateSelectedImages(ClickableFrame *clickedFrame);
+    void fetchRandomImages(int numImages);
 
-    void handleImageResponse();
-    void fetchRandomImages();
-
+    // image methods
+    cv::Mat qimage_to_mat(const QImage& img);
 };
 
 #endif // PICKIMAGESPAGE_H

--- a/application/src/pages/projectpage.cpp
+++ b/application/src/pages/projectpage.cpp
@@ -1,14 +1,143 @@
 #include "projectpage.h"
 #include "ui_projectpage.h"
+#include "imageprojectionwindow.h"
 
-ProjectPage::ProjectPage(QWidget *parent)
+#include <QVBoxLayout>
+#include <opencv2/imgcodecs.hpp>
+
+ProjectPage::ProjectPage(ImageProjectionWindow *projectionWindow, QWidget *parent)
     : QWidget(parent)
     , ui(new Ui::ProjectPage)
+    , m_imageLabel(nullptr)
 {
     ui->setupUi(this);
+    initializeUI();
 }
 
 ProjectPage::~ProjectPage()
 {
     delete ui;
+}
+
+void ProjectPage::initializeUI()
+{
+    setStyleSheet("background-color: #1E1E1E;");
+
+    QVBoxLayout *mainLayout = new QVBoxLayout(this);
+    mainLayout->setContentsMargins(30, 20, 30, 20);
+    mainLayout->setSpacing(15);
+
+    mainLayout->addWidget(createTitleLabel(), 0, Qt::AlignHCenter);
+
+    mainLayout->addWidget(createImageFrame(), 1, Qt::AlignHCenter);
+
+    mainLayout->addLayout(createButtonLayout());
+
+    setLayout(mainLayout);
+
+    connect(ui->doneButton, &QPushButton::clicked, this, &ProjectPage::onDoneButtonClicked);
+    connect(ui->rejectButton, &QPushButton::clicked, this, &ProjectPage::onRejectButtonClicked);
+}
+
+void ProjectPage::setSelectedImage(const cv::Mat& mat)
+{
+    if (mat.empty() || mat.type() != CV_8UC3) {
+        qDebug("Invalid image format. Expected non-empty CV_8UC3.");
+        return;
+    }
+
+    // Convert cv::Mat to QImage without copying data
+    QImage qimg(mat.data, mat.cols, mat.rows, mat.step, QImage::Format_RGB888);
+
+    // Scale the image to fit the label while maintaining aspect ratio
+    m_imageLabel->setPixmap(QPixmap::fromImage(qimg).scaled(m_imageLabel->size(), Qt::KeepAspectRatio, Qt::SmoothTransformation));
+}
+
+QLabel* ProjectPage::createTitleLabel()
+{
+    QLabel *titleLabel = new QLabel("Change The Sensitivity of the Outline", this);
+    titleLabel->setStyleSheet(
+        "color: white;"
+        "font-size: 30px;"
+        "font-weight: bold;"
+        "background-color: #3E3E3E;"
+        "border-radius: 20px;"
+        "padding: 15px 20px;"
+        );
+    titleLabel->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Minimum);
+    titleLabel->setFixedWidth(800);
+    titleLabel->setAlignment(Qt::AlignCenter | Qt::AlignVCenter);
+    return titleLabel;
+}
+
+QFrame* ProjectPage::createImageFrame()
+{
+    QFrame *imageFrame = new QFrame(this);
+    imageFrame->setFrameStyle(QFrame::Box | QFrame::Raised);
+    imageFrame->setLineWidth(2);
+    imageFrame->setStyleSheet("border-radius: 10px; background-color: #2E2E2E;");
+    imageFrame->setFixedWidth(800);
+    imageFrame->setContentsMargins(3, 3, 3, 3);
+
+    QVBoxLayout *cameraLayout = new QVBoxLayout(imageFrame);
+    m_imageLabel = new QLabel(this);
+    m_imageLabel->setAlignment(Qt::AlignCenter);
+    m_imageLabel->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+    cameraLayout->addWidget(m_imageLabel);
+
+    return imageFrame;
+}
+
+
+QHBoxLayout* ProjectPage::createButtonLayout()
+{
+    QHBoxLayout *buttonLayout = new QHBoxLayout();
+    buttonLayout->addWidget(styleButton(ui->rejectButton, "REVISE VISION", "#CD6F6F"));
+    buttonLayout->addWidget(styleButton(ui->doneButton, "FINISHED PROJECTING", "#BB64C7"));
+    return buttonLayout;
+}
+
+QPushButton* ProjectPage::styleButton(QPushButton* button, const QString& text, const QString& bgColor)
+{
+    // Compute the darker color by applying a 30% reduction
+    QString darkerColor;
+    if (bgColor == "#CD6F6F") {
+        darkerColor = "#8B4D4D";  // 30% darker color for red
+    } else if (bgColor == "#BB64C7") {
+        darkerColor = "#83468B";  // 30% darker color for purple
+    } else {
+        darkerColor = "#4A5A9F";  // Default color (if none of the above match)
+    }
+
+    button->setText(text);
+    button->setFixedSize(200, 50);
+    button->setStyleSheet(QString(
+                              "QPushButton {"
+                              "   background-color: %1;"  // Original color
+                              "   color: black;"
+                              "   border-radius: 25px;"
+                              "   font-weight: bold;"
+                              "   font-size: 16px;"
+                              "}"
+                              "QPushButton:hover {"
+                              "   background-color: %2;"  // 30% darker color for hover
+                              "}"
+                              "QPushButton:pressed {"
+                              "   background-color: %3;"  // 30% darker color for pressed
+                              "}"
+                              ).arg(bgColor).arg(darkerColor).arg(darkerColor));
+
+    // Set the hand cursor when hovering over the button
+    button->setCursor(Qt::PointingHandCursor);
+    return button;
+}
+
+void ProjectPage::onRejectButtonClicked()
+{
+    emit navigateToPickImagesPage();
+}
+
+void ProjectPage::onDoneButtonClicked()
+{
+    emit navigateToCreatePage();
 }

--- a/application/src/pages/projectpage.h
+++ b/application/src/pages/projectpage.h
@@ -1,7 +1,12 @@
 #ifndef PROJECTPAGE_H
 #define PROJECTPAGE_H
+#include "imageprojectionwindow.h"
 
 #include <QWidget>
+#include <QLabel>
+#include <QHBoxLayout>
+#include <QPushButton>
+#include <opencv2/imgproc.hpp>
 
 namespace Ui {
 class ProjectPage;
@@ -12,11 +17,28 @@ class ProjectPage : public QWidget
     Q_OBJECT
 
 public:
-    explicit ProjectPage(QWidget *parent = nullptr);
+    explicit ProjectPage(ImageProjectionWindow *projectionWindow, QWidget *parent = nullptr);
     ~ProjectPage();
+    void setSelectedImage(const cv::Mat& selectedImage);
+
+signals:
+    void navigateToPickImagesPage();
+    void navigateToCreatePage();
+
+private slots:
+    void onRejectButtonClicked();
+    void onDoneButtonClicked();
 
 private:
     Ui::ProjectPage *ui;
+    QLabel* m_imageLabel;
+
+    // UI methods
+    void initializeUI();
+    QLabel* createTitleLabel();
+    QFrame* createImageFrame();
+    QHBoxLayout* createButtonLayout();
+    QPushButton* styleButton(QPushButton* button, const QString& text, const QString& bgColor);
 };
 
 #endif // PROJECTPAGE_H

--- a/application/src/pages/projectpage.ui
+++ b/application/src/pages/projectpage.ui
@@ -26,6 +26,32 @@
     <string>Project Page</string>
    </property>
   </widget>
+  <widget class="QPushButton" name="rejectButton">
+   <property name="geometry">
+    <rect>
+     <x>140</x>
+     <y>340</y>
+     <width>100</width>
+     <height>32</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Reject</string>
+   </property>
+  </widget>
+  <widget class="QPushButton" name="doneButton">
+   <property name="geometry">
+    <rect>
+     <x>370</x>
+     <y>340</y>
+     <width>100</width>
+     <height>32</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Done</string>
+   </property>
+  </widget>
  </widget>
  <resources/>
  <connections/>

--- a/application/src/pages/sensitivitypage.cpp
+++ b/application/src/pages/sensitivitypage.cpp
@@ -237,6 +237,4 @@ void SensitivityPage::updateSensitivity()
     } else {
         qDebug() << "Projection window is not set.";
     }
-
-    // qDebug() << "Sensitivity Updated - Lower:" << lowerValue << ", Upper:" << upperValue;
 }

--- a/application/src/utils/image_utils.h
+++ b/application/src/utils/image_utils.h
@@ -1,0 +1,20 @@
+// image_utils.h
+
+#ifndef IMAGE_UTILS_H
+#define IMAGE_UTILS_H
+
+#include <QImage>
+#include <opencv2/core/mat.hpp>
+
+namespace ImageUtils {
+
+cv::Mat qimage_to_mat(const QImage& img) {
+    if (img.format() != QImage::Format_RGB888) {
+        return cv::Mat();
+    }
+    return cv::Mat(img.height(), img.width(), CV_8UC3, const_cast<uchar*>(img.bits()), img.bytesPerLine()).clone();
+}
+
+}  // namespace ImageUtils
+
+#endif // IMAGE_UTILS_H


### PR DESCRIPTION
What?
Made the basic UI for the projectPage. Only shows the projected image, a reject, and a finished button. The reject goes back to the pick image page and the finished goes back to the create page. 

Also, connected the selection of the images to the proj. window, which shows the selected image and the rainbow image if nothing is selected. 


Resolves #16.

Issues:
- the color changes for some reason when it gets displayed on the image projection window. (even tho both are a cv::mat)
- since the image doesnt cover the entire window it displays white, we would need to figure out how to display nothing 
- more improvements on details of the UI (like sizing, etc.)
- (MAJOR) the applyPerspectiveTransform() function turns the image black, so no transforms are being done because I didn't use it. 